### PR TITLE
Remove manual quoting of option arguments.

### DIFF
--- a/panopy/pano.py
+++ b/panopy/pano.py
@@ -37,9 +37,9 @@ def process_arg(key, value):
     elif isinstance(value, basestring):
         value = os.path.expanduser(filename_replace(value))
         if len(key) > 1:
-            return ['--{key}={value}'.format(key=key, value='"' + value + '"' if ' ' in value else value)]
+            return ['--{key}={value}'.format(key=key, value=value)]
         else:
-            return ['-{key}'.format(key=key), '{value}'.format(value='"' + value + '"' if ' ' in value else value)]
+            return ['-{key}'.format(key=key), '{value}'.format(value=value)]
     else: # it's a list?
         return [item for subval in value for item in process_arg(key, subval)]
 


### PR DESCRIPTION
Subprocess handles the quoting of arguments, so there is no need to manually quote them in case they contain a space. In fact, the quotes will be escaped by subprocess, so the argument value will contain the literal quotes.

I noticed this when passing font names to the latex template:

``` yaml
latex:
    o: '%.tex'
    number-sections:
    variable:
        - documentclass:scrartcl
        - mainfont:Linux Libertine
        - sansfont:Linux Biolinum
```
